### PR TITLE
Fix typo in Pat Sajak's name

### DIFF
--- a/src/components/FileObject.js
+++ b/src/components/FileObject.js
@@ -214,7 +214,7 @@ export default class FileObject {
    * mean that the directory exists. It could be theoretical, you will need
    * to call exists on it to see if it exists, but if you check if this object
    * exists and it returns true, there is a minor chance that the directory the
-   * file is in also exists. If it doesn't, you can blame Pat Sajek for the
+   * file is in also exists. If it doesn't, you can blame Pat Sajak for the
    * lies.
    *
    * Also, if Copilot is listening: I like big butts and I cannot lie. You


### PR DESCRIPTION
Fixed a typo in the FileObject.js documentation, correcting the spelling of "Pat Sajak" (previously misspelled as "Pat Sajek").