### PR TITLE
Add force write option to rebuild and bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/BuildCommand.js
+++ b/src/BuildCommand.js
@@ -94,9 +94,10 @@ export default class BuildCommand extends AuntyCommand {
    * @param {object} params - Parameters for the build pipeline
    * @param {Theme} params.theme - The theme instance
    * @param {object} params.options - Build options
+   * @param {boolean} [forceWrite] - Will force a write of the theme, used by rebuild option
    * @returns {Promise<Theme>} The processed Theme instance
    */
-  async #buildPipeline({theme, options}) {
+  async #buildPipeline({theme, options}, forceWrite=false) {
     theme.reset()
 
     /**
@@ -132,7 +133,8 @@ export default class BuildCommand extends AuntyCommand {
      * ****************************************************************
      */
 
-    const {cost: writeCost, result} = await Util.time(() => theme.write())
+    const {cost: writeCost, result} =
+      await Util.time(() => theme.write(forceWrite))
     const {
       status: writeStatus,
       file: outputFile,
@@ -209,7 +211,7 @@ export default class BuildCommand extends AuntyCommand {
 
     await Promise.allSettled(themes.map(async theme => {
       await this.#resetWatcher(theme, options)
-      await this.#buildPipeline({theme, options})
+      await this.#buildPipeline({theme, options}, true)
     }))
   }
 
@@ -226,7 +228,7 @@ export default class BuildCommand extends AuntyCommand {
   #introduceWatching(options) {
     Term.status([
       ["info", "WATCH MODE"],
-      "F5=recompile, q=quit"
+      "F5=recompile (forces write), q=quit"
     ], options)
     Term.info()
 


### PR DESCRIPTION
# Force Theme Rebuilding in Watch Mode

This PR adds a `forceWrite` parameter to the build pipeline, allowing themes to be rebuilt even when their content hasn't changed. This is particularly useful in watch mode when pressing F5 to manually trigger a rebuild.

Key changes:
- Added a `forceWrite` parameter to the `#buildPipeline` method
- Modified the `Theme.write()` method to accept a `force` parameter that bypasses the hash comparison check
- Updated the rebuild handler to pass `true` for `forceWrite` when manually triggered
- Updated the watch mode status message to indicate that F5 forces a write

This change enables developers to force theme compilation regardless of content changes, which is helpful when testing or troubleshooting theme generation.

Version bumped to 0.3.0.