### PR TITLE
Fix variable reference handling in resolution and bump version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/ResolveCommand.js
+++ b/src/ResolveCommand.js
@@ -121,14 +121,19 @@ export default class ResolveCommand extends AuntyCommand {
       if(!reference) {
         acc.push(curr)
       } else {
-        if(breadcrumbs.has(reference)) {
-          const fork = breadcrumbs.get(reference)
-          const forked = this.#getFullTrail(reference, fork, breadcrumbs)
+        // Extract the lookup key from the reference syntax
+        const lookupKey = reference.startsWith("$(") ?
+          reference.slice(2, -1) :
+          reference.startsWith("${") ?
+            reference.slice(2, -1) :
+            reference.slice(1)  // Handle $var
 
-          forked.unshift(reference)
+        if(breadcrumbs.has(lookupKey)) {
+          // Use lookupKey for breadcrumb lookup, but display reference
+          const fork = breadcrumbs.get(lookupKey)
+          const forked = this.#getFullTrail(lookupKey, fork, breadcrumbs)
+          forked.unshift(reference)  // Display original syntax
           acc.push(forked)
-        } else {
-          acc.push(curr)
         }
       }
 
@@ -164,11 +169,6 @@ export default class ResolveCommand extends AuntyCommand {
       // classify
       const isFunction = /^\w+\(.*\)$/.test(item)
       const isHex = Colour.longHex.test(item) || Colour.shortHex.test(item)
-      const isVariable = Evaluator.sub.test(item)
-
-      if(!(isVariable || isFunction || isHex))
-        return
-
       const curr = isFunction ? "function" : (isHex ? "hex" : "variable")
       const showElbow = (out.length === 0) || (last === "function" && curr !== "function")
       const prefix = pad.repeat(indent)

--- a/src/components/Evaluator.js
+++ b/src/components/Evaluator.js
@@ -184,9 +184,11 @@ export default class Evaluator {
 
         if(resolved !== text) {
           // Now let's see if we have a pre-existing breadcrumb resolution!
-          if(lookupValue && lookupKey !== token) {
+          if(lookupValue &&
+            lookupKey !== token &&
+            this.#breadcrumbs.has(lookupKey)) {
             // Woot! Okay, let's add a reference for later use when resolving
-            this.#recordBreadcrumb(token, [text,`{{${lookupKey}}}`,resolved])
+            this.#recordBreadcrumb(token, [text,`{{${captured}}}`,resolved])
           } else {
             this.#recordBreadcrumb(token, [text, resolved])
           }


### PR DESCRIPTION
# Fix Variable Reference Resolution in Theme Evaluation

This PR fixes issues with variable reference resolution in the theme evaluation process:

1. Improved handling of different variable syntax formats (`$var`, `$(var)`, `${var}`) in the `#getFullTrail` method to correctly extract lookup keys.

2. Modified the reference resolution logic to use the extracted lookup key for breadcrumb lookups while preserving the original syntax for display.

3. Fixed breadcrumb recording in the Evaluator class to:
   - Only record when the breadcrumb actually exists
   - Use the captured variable name instead of the lookup key for better reference tracking

Version bumped from 0.5.0 to 0.5.1.
