### PR TITLE
Add semantic token color support and bump version to 0.6.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -70,6 +70,23 @@
       "console": "integratedTerminal"
     },
     {
+      "name": "Advanced (YAML) (semantics)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run-script",
+        "exec",
+        "build",
+        "--",
+        "--output-dir",
+        "./examples/output",
+        "./examples/advanced/src/blackboard-semantics.yaml"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Advanced (YAML) (watch)",
       "type": "node",
       "request": "launch",

--- a/examples/advanced/import/semantics.yaml
+++ b/examples/advanced/import/semantics.yaml
@@ -1,0 +1,31 @@
+theme:
+  tokenColors:
+    - settings:
+        foreground: "#909090"
+  semanticTokenColors:
+    # Literals - keep them close to your existing syntax colors
+    stringLiteral: $colors.green     # Your existing string color
+    numberLiteral: $colors.blue      # Match your accent for important literals
+    customLiteral: lighten($colors.orange, 15)  # Slightly warmer for user-defined
+
+    # Operators and keywords - use your accent system
+    newOperator: $std.fg.accent.secondary       # Your blue accent
+    keyword: $colors.purple                     # Distinguish from regular keywords
+
+    # Types and declarations - semantic meaning
+    type: $colors.teal                          # Your secondary accent
+    class: lighten($colors.teal, 25)            # Brighter for class names
+    interface: $colors.teal                     # Match types
+    namespace: $colors.orange                   # Warm for organizational constructs
+
+    # Variables and references
+    variable: $std.fg                           # Default foreground
+    parameter: lighten($colors.blue, 30)       # Lighter than accent
+    property: $colors.yellow                    # Distinct for object properties
+
+    # Functions and methods
+    function: $colors.orange                    # Warm, inviting
+    method: $colors.orange                      # Match functions
+
+    # Comments and documentation
+    comment: fade($std.fg, 0.6)                # Your existing comment style

--- a/examples/advanced/src/blackboard-semantics.yaml
+++ b/examples/advanced/src/blackboard-semantics.yaml
@@ -1,0 +1,31 @@
+# Theme Config
+config:
+  $schema: vscode://schemas/color-theme
+  name: blackboard
+  type: dark
+
+  import:
+    global: ../import/variables.yaml
+    colors:
+      - ../import/colors.yaml
+    semanticTokenColors:
+      - ../import/semantics.yaml
+
+  custom:
+    semanticHighlighting: true
+    colorSpaceName: sRGB
+
+vars:
+  main: $(colors.white)
+  inverse: invert($main)
+
+  std:
+    # The following define primary basics that can be relied upon by the
+    # variables definitions. Dark and light themes will define these
+    # differently. Anything expressed here will override anything being
+    # imported.
+    fg: $(main)
+    bg: $(inverse)
+    accent: $(colors.blue)
+    accent.secondary: $(colors.teal)
+    shadow: alpha($(std.accent), 0.25)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/components/Compiler.js
+++ b/src/components/Compiler.js
@@ -10,7 +10,6 @@ import * as File from "./File.js"
 import FileObject from "./FileObject.js"
 import AuntyError from "./AuntyError.js"
 import _Term from "./Term.js"
-import Term from "./Term.js"
 
 /**
  * Main compiler class for processing theme source files.
@@ -63,19 +62,29 @@ export default class Compiler {
       imported.global,
       imported.colors,
       imported.tokenColors,
+      imported.semanticTokenColors,
       sourceObj
     )
 
     // Shred them up! Kinda.
-    const decompVars = this.#decomposeObject(merged.vars)
-    const decompColors = this.#decomposeObject(merged.theme.colors)
-    const decompTokenColors = this.#decomposeObject(merged.theme.tokenColors)
+    const decompVars =
+      this.#decomposeObject(merged.vars)
+    const decompColors =
+      this.#decomposeObject(merged.theme.colors)
+    const decompTokenColors =
+      this.#decomposeObject(merged.theme.tokenColors)
+    const decompSemanticTokenColors =
+      this.#decomposeObject(merged.theme.semanticTokenColors)
 
     // First let's evaluate the variables
     evaluate(decompVars) // but we don't need the return value, only the lookup
     theme.lookup = evaluator.lookup
-    const evalColors = evaluate(decompColors, theme.lookup)
-    const evalTokenColors = evaluate(decompTokenColors, theme.lookup)
+    const evalColors =
+      evaluate(decompColors, theme.lookup)
+    const evalTokenColors =
+      evaluate(decompTokenColors, theme.lookup)
+    const evalSemanticTokenColors =
+      evaluate(decompSemanticTokenColors, theme.lookup)
 
     // Now let's do some reducing... into a form that works for VS Code
     const reducer = (acc,curr) => {
@@ -85,7 +94,8 @@ export default class Compiler {
     // Assemble into one object with the proper keys
     const colors = evalColors.reduce(reducer, {})
     const tokenColors = this.#composeArray(evalTokenColors)
-    const themeColours = {colors,tokenColors}
+    const semanticTokenColors = evalSemanticTokenColors.reduce(reducer, {})
+    const themeColours = {colors,semanticTokenColors,tokenColors}
     // Mix and maaatch all jumbly wumbly...
     const output = Data.mergeObject(
       {},

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -197,7 +197,6 @@ export default class Theme {
   async build(buildOptions) {
     const compiler = new Compiler()
     await compiler.compile(this, buildOptions)
-    // await this.#compileTheme(this.#options, buildOptions)
   }
 
   /**


### PR DESCRIPTION
# Add semantic token color support

This PR adds support for semantic token colors in theme definitions, allowing for more precise syntax highlighting based on language semantics rather than just syntax patterns.

Key changes:
- Added a new example file `blackboard-semantics.yaml` demonstrating semantic token color usage
- Created a semantic token colors import file with common semantic token definitions
- Updated the Compiler to process and evaluate semantic token colors
- Added a VS Code launch configuration for testing the semantic token colors example
- Bumped version to 0.6.0 to reflect the new feature

Semantic token colors provide more accurate highlighting for language-specific constructs like variables, functions, types, and other programming elements that traditional syntax highlighting can't distinguish.