### PR TITLE
Remove duplicate pool assignment in Theme class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/components/Theme.js
+++ b/src/components/Theme.js
@@ -63,7 +63,6 @@ export default class Theme {
     this.#outputHash = null
     this.#lookup = null
     this.#pool = null
-    this.#pool = null
   }
 
   /**


### PR DESCRIPTION
Removed duplicate `this.#pool = null` assignment in Theme class cleanup method.