### PR TITLE
Add semantic dark theme and enhance terminal output formatting, bump version to 0.8.0

### DIFF
--- a/examples/advanced/import/semantic-dark.yaml
+++ b/examples/advanced/import/semantic-dark.yaml
@@ -1,0 +1,38 @@
+theme:
+  semanticTokenColors:
+    # Token Types
+    namespace: $colors.orange
+    class: $colors.teal
+    enum: lighten($colors.teal, 25)
+    interface: $colors.teal
+    struct: $colors.teal
+    typeParameter: lighten($colors.blue, 30)
+    type: $colors.teal
+    parameter: lighten($colors.blue, 30)
+    variable: $std.fg
+    property: $colors.yellow
+    enumMember: $colors.blue
+    decorator: $colors.purple
+    event: $colors.orange
+    function: $colors.orange
+    method: $colors.orange
+    macro: $colors.purple
+    label: $colors.green
+    comment: $colors.red
+    string: $colors.green
+    keyword: $colors.purple
+    number: $colors.blue
+    regexp: $colors.orange
+    operator: $std.fg.accent.secondary
+
+    # Token Modifiers (can be combined with types)
+    declaration: lighten($std.fg, 15)
+    definition: lighten($std.fg, 25)
+    readonly: fade($std.fg, 0.8)
+    static: $colors.purple
+    deprecated: fade($std.fg, 0.5)
+    abstract: fade($colors.teal, 0.8)
+    async: $colors.blue
+    modification: $colors.orange
+    documentation: fade($colors.green, 0.7)
+    defaultLibrary: $colors.teal

--- a/examples/advanced/src/blackboard-semantics.yaml
+++ b/examples/advanced/src/blackboard-semantics.yaml
@@ -8,6 +8,8 @@ config:
     global: ../import/variables.yaml
     colors:
       - ../import/colors.yaml
+    tokenColors:
+      - ../import/karyprocolors-$(type).tmLanguage.yaml
     semanticTokenColors:
       - ../import/semantics.yaml
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/components/File.js
+++ b/src/components/File.js
@@ -16,6 +16,7 @@ import FileObject from "./FileObject.js"
 import DirectoryObject from "./DirectoryObject.js"
 import {uniformStringArray} from "./DataUtil.js"
 import AuntyError from "./AuntyError.js"
+import Term from "./Term.js"
 
 /**
  * Fix slashes in a path

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -15,6 +15,8 @@ ansiColors.alias("error", ansiColors.redBright)
 ansiColors.alias("error-bracket", ansiColors.red)
 ansiColors.alias("modified", ansiColors.magentaBright)
 ansiColors.alias("modified-bracket", ansiColors.magenta)
+ansiColors.alias("muted", ansiColors.white.dim.italic)
+ansiColors.alias("muted-bracket", ansiColors.blackBright.italic)
 
 export default class Term {
   /**
@@ -92,6 +94,8 @@ export default class Term {
    *  - array: each element is either:
    *    - a plain string (emitted unchanged), or
    *    - a tuple: [level, text] where `level` maps to an ansiColors alias
+   *        (e.g. success, info, warn, error, modified).
+   *    - a tuple: [level, text, [openBracket,closeBracket]] where `level` maps to an ansiColors alias
    *        (e.g. success, info, warn, error, modified). These are rendered as
    *        colourised bracketed segments: [TEXT].
    *
@@ -102,7 +106,7 @@ export default class Term {
    * Recursion: array input is normalised into a single string then re-dispatched
    * through `status` to leverage the string branch (keeps logic DRY).
    *
-   * @param {string | Array<string | [string, string]>} args - Message spec.
+   * @param {string | Array<string, string> | Array<string, string, string>} args - Message spec.
    * @returns {void}
    */
   static terminalMessage(args) {
@@ -114,7 +118,12 @@ export default class Term {
         .map(curr => {
           // Bracketed
           if(Array.isArray(curr))
-            return Term.terminalBracket(curr)
+
+            if(curr.length === 3 && Array.isArray(curr[2]))
+              return Term.terminalBracket(curr)
+
+            else
+              return Term.terminalBracket([...curr, ["",""]])
 
           // Plain string, no decoration
           if(typeof curr === "string")
@@ -152,13 +161,13 @@ export default class Term {
    * @returns {string} Colourised bracketed segment (e.g. "[TEXT]").
    * @throws {AuntyError} If any element of `parts` is not a string.
    */
-  static terminalBracket([level, text]) {
+  static terminalBracket([level, text, brackets=["",""]]) {
     if(!(typeof level === "string" && typeof text === "string"))
       throw AuntyError.new("Each element must be a string.")
 
     return "" +
-        ansiColors[`${level}-bracket`]("[")
+        ansiColors[`${level}-bracket`](brackets[0])
       + ansiColors[level](text)
-      + ansiColors[`${level}-bracket`]("]")
+      + ansiColors[`${level}-bracket`](brackets[1])
   }
 }


### PR DESCRIPTION
# Enhanced Terminal Output and Added Semantic Token Colors

This PR introduces semantic token colors for dark themes and improves the terminal output formatting in the build command. Key changes include:

1. Added `semantic-dark.yaml` with comprehensive token color definitions for various code elements like namespaces, classes, functions, and modifiers
2. Updated the Blackboard semantics theme to import token colors
3. Enhanced terminal output formatting with customizable brackets ([], {}, ()) for different message types
4. Improved dependency reporting in build output with detailed file information
5. Added a "muted" color style for less important information
6. Added an HTML test file for token highlighting verification
7. Bumped version from 0.7.1 to 0.8.0

The terminal output now shows more detailed information about compiled files when using the `--nerd` flag, making it easier to track dependencies and file sizes during theme compilation.