### PR TITLE
Pass cache to Theme instance and bump version to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/aunty",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "displayName": "Aunty Rose",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/ResolveCommand.js
+++ b/src/ResolveCommand.js
@@ -78,6 +78,7 @@ export default class ResolveCommand extends AuntyCommand {
 
     const fileObject = await this.resolveThemeFileName(inputArg, cwd)
     const theme = new Theme(fileObject, options)
+    theme.cache = this.cache
 
     await theme.load()
     await theme.build()


### PR DESCRIPTION
# Bump version to 0.10.1 and fix theme cache reference

This PR makes two changes:
1. Bumps the package version from 0.10.0 to 0.10.1
2. Adds a missing cache reference to the theme object in ResolveCommand.js, ensuring the theme has access to the cache property

The cache reference fix addresses an issue where themes couldn't access the cache during resolution.