### PR TITLE
Remove extra space in gold color and @private tags from RegExp docs

### DIFF
--- a/examples/advanced/import/variables.yaml
+++ b/examples/advanced/import/variables.yaml
@@ -12,7 +12,7 @@ vars:
     purple: oklch(0.641 0.21 327.7)
     pink: oklch(0.809 0.146 340.6)
     teal: oklch(0.431 0.049 231.1)
-    gold: oklch(0.86  0.168 87.8)
+    gold: oklch(0.86 0.168 87.8)
 
   # The following define secondary basics that can be relied upon by the
   # theme's definition.

--- a/src/Evaluator.js
+++ b/src/Evaluator.js
@@ -44,7 +44,6 @@ export default class Evaluator {
    * of wrapping style. The pattern captures (entireMatch, posix, legacy,
    * braced).
    *
-   * @private
    * @type {RegExp}
    */
   static sub = /(?<captured>\$\((?<parens>[^()]+)\)|\$(?<none>[\w]+(?:\.[\w]+)*)|\$\{(?<braces>[^()]+)\})/
@@ -53,7 +52,6 @@ export default class Evaluator {
    * Regular expression for matching colour / transformation function calls
    * within token strings, e.g. `darken($(std.accent), 10)`.
    *
-   * @private
    * @type {RegExp}
    */
   static func = /(?<captured>(?<func>\w+)\((?<args>[^()]+)\))/


### PR DESCRIPTION
Fixed formatting in variables.yaml and removed @private annotations in Evaluator.js

This PR makes two small changes:
1. Removes an extra space in the gold color definition in variables.yaml
2. Removes unnecessary @private JSDoc annotations from the static RegExp properties in Evaluator.js