### PR TITLE
Revamp theme import system and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npx @gesslar/sassy lint my-theme.yaml
 
 ### Debugging Your Themes
 
-**See what a color variable resolves to:**
+**See what a colour variable resolves to:**
 
 ```bash
 npx @gesslar/sassy resolve --color editor.background my-theme.yaml
@@ -119,7 +119,7 @@ npx @gesslar/sassy resolve --color editor.background my-theme.yaml
 npx @gesslar/sassy resolve --tokenColor keyword.control my-theme.yaml
 ```
 
-**Debug semantic token colors:**
+**Debug semantic token colours:**
 
 ```bash
 npx @gesslar/sassy resolve --semanticTokenColor variable.readonly my-theme.yaml
@@ -147,7 +147,7 @@ npx @gesslar/sassy lint my-theme.yaml
 ```
 
 The lint command performs comprehensive validation of your theme files to catch
-common issues that could cause unexpected behavior or poor maintainability.
+common issues that could cause unexpected behaviour or poor maintainability.
 
 ### Lint Command Checks
 
@@ -423,13 +423,12 @@ vars:
 config:
   name: "My Theme"
   type: dark
-  imports:
-    vars:
-      colors: "./colours.yaml"
+  import:
+    - "./colours.yaml"
 
 vars:
   # Use imported colours
-  accent: $(colors.palette.primary)
+  accent: $(palette.primary)
 
   # Build your design system
   std:
@@ -451,49 +450,48 @@ Sassy supports importing different types of theme components:
 
 ```yaml
 config:
-  imports:
-    # Import variables (merged into your vars section)
-    vars:
-      colors: "./shared/colours.yaml"
-      # Can import multiple files
-      typography: ["./shared/fonts.yaml", "./shared/sizes.yaml"]
-
-    # Import global configuration
-    global:
-      base: "./shared/base-config.yaml"
-
-    # Import VS Code colour definitions
-    colors:
-      ui: "./shared/ui-colours.yaml"
-
-    # Import syntax highlighting rules
-    tokenColors:
-      syntax: "./shared/syntax.yaml"
-
-    # Import semantic token colours
-    semanticTokenColors:
-      semantic: "./shared/semantic.yaml"
+  import:
+    - "./shared/colours.yaml"        # Variables and base config
+    - "./shared/ui-colours.yaml"     # VS Code color definitions  
+    - "./shared/syntax.yaml"         # Syntax highlighting rules
+    - "./shared/semantic.yaml"       # Semantic token colours
 ```
 
-**Import Format Options:**
+**Import Format:**
 
-- **Single file:** `"./path/to/file.yaml"`
-- **Multiple files:** `["./file1.yaml", "./file2.yaml"]`
+Imports are a simple array of file paths. Each file gets merged into your theme:
+
+- **Files:** `["./file1.yaml", "./file2.yaml", "./file3.yaml"]`
 - **File types:** Both `.yaml` and `.json5` are supported
 
 **Merge Order:**
 
-The merge happens in a precise order with each level overriding the previous:
+The merge behaviour depends on the type of theme content:
 
-1. `global` imports (merged first)
-2. `colors` imports
-3. `tokenColors` imports
-4. `semanticTokenColors` imports
-5. Your theme file's own definitions (final override)
+**Objects (composable):** `colors`, `semanticTokenColors`, `vars`, `config`
 
-Within each section, if you import multiple files, they merge in array order.
-This layered approach gives you fine-grained control over which definitions
-take precedence.
+1. Imported files (merged in import order)
+2. Your theme file's own definitions (final override)
+
+Later sources override earlier ones using deep object merging.
+
+**Arrays (append-only):** `tokenColors`
+
+1. All imported `tokenColors` (in import order)
+2. Your theme file's `tokenColors` (appended last)
+
+**Why different?** VS Code reads `tokenColors` from top to bottom and stops at the first matching rule. This means:
+
+- **Imported rules** = specific styling (e.g., "make function names blue")
+- **Your main file rules** = fallbacks (e.g., "if nothing else matched, make it white")
+
+**Examples:**
+
+- If an import defines `keyword.control` and your main file also defines `keyword.control`, VS Code will use the imported version because it appears first in the final array.
+
+- If your import has a broad rule like `storage` and your main file has a specific rule like `storage.type`, the broad `storage` rule will match first and your specific `storage.type` rule will never be used.
+
+> **Tip:** If you're unsure about rule precedence or conflicts, run `npx @gesslar/sassy lint your-theme.yaml` to see exactly what's happening with your `tokenColors`.
 
 ### Watch Mode for Development
 
@@ -574,7 +572,7 @@ different approaches and techniques.
 npx @gesslar/sassy build --nerd my-theme.yaml
 
 # Check what a specific variable resolves to
-npx @gesslar/sassy resolve --token problematic.variable my-theme.yaml
+npx @gesslar/sassy resolve --color problematic.variable my-theme.yaml
 ```
 
 **Variables not resolving:**
@@ -585,9 +583,10 @@ npx @gesslar/sassy resolve --token problematic.variable my-theme.yaml
 
 **Watch mode not updating:**
 
-- Check that files aren't being saved outside the watched directory
-- Try restarting watch mode
-- Verify file permissions
+- Ensure you're editing the original `.yaml` file (not the compiled `.color-theme.json`)
+- Check that imported files are in the same directory tree as your main theme
+- Try restarting watch mode if it seems stuck
+- Verify file permissions allow reading your theme files
 
 ## Getting Help
 

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -58,15 +58,27 @@ export default class Compiler {
 
       theme.dependencies = importedFiles
 
+      // Handle tokenColors separately - imports first, then main source
+      // (append-only)
+      const mergedTokenColors = [
+        ...(imported.tokenColors ?? []),
+        ...(sourceTheme?.tokenColors ?? [])
+      ]
+
       const merged = Data.mergeObject({},
         imported,
         {
           vars: sourceVars ?? {},
           colors: sourceTheme?.colors ?? {},
-          tokenColors: sourceTheme?.tokenColors ?? [],
           semanticTokenColors: sourceTheme?.semanticTokenColors ?? {},
         }
       )
+
+      // Add tokenColors after merging to avoid mergeObject processing
+      merged.tokenColors = mergedTokenColors
+
+      Term.debug(JSON.stringify(merged))
+
 
       // Shred them up! Kinda. And evaluate the variables in place
       const vars = this.#decomposeObject(merged.vars)
@@ -173,7 +185,7 @@ export default class Compiler {
 
       imported.vars = Data.mergeObject(imported.vars, vars)
       imported.colors = Data.mergeObject(imported.colors, colors)
-      imported.tokenColors = Data.mergeArray(imported.tokenColors, tokenColors)
+      imported.tokenColors = [...imported.tokenColors, ...tokenColors]
     })
 
     return {imported,importedFiles}

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -77,9 +77,6 @@ export default class Compiler {
       // Add tokenColors after merging to avoid mergeObject processing
       merged.tokenColors = mergedTokenColors
 
-      Term.debug(JSON.stringify(merged))
-
-
       // Shred them up! Kinda. And evaluate the variables in place
       const vars = this.#decomposeObject(merged.vars)
       evaluate(vars)

--- a/src/Data.js
+++ b/src/Data.js
@@ -520,26 +520,4 @@ export default class Data {
     return arr.filter((_, index) => results[index])
   }
 
-  /**
-   * Shallowly merges multiple arrays, deduplicating while preserving order.
-   *
-   * @param {...any[]} sources - Arrays to merge
-   * @returns {Array} A new merged array
-   * @throws {Error} If the sources are not all arrays
-   */
-  static mergeArray(...sources) {
-    if(sources.some(source => !Array.isArray(source)))
-      throw Sass.new("All sources to mergeArray must be arrays.")
-
-    return sources.reduce((acc, curr) => {
-      const accSet = new Set(acc)
-
-      curr.forEach(value => {
-        accSet.has(value) && accSet.delete(value)
-        accSet.add(value)
-      })
-
-      return Array.from(accSet)
-    }, [])
-  }
 }


### PR DESCRIPTION
# Improved Theme Import System with Clearer Merge Behavior

This PR updates the theme import system to use a simpler, more predictable approach:

- Changed `config.imports` to a flat array under `config.import` for easier usage
- Implemented different merge behaviors based on content type:
  - Objects (vars, colors, semanticTokenColors): Deep merge with override semantics
  - Arrays (tokenColors): Append-only concatenation preserving import order

This distinction is important because tokenColors in VS Code are processed sequentially (first match wins), making composition different from other theme components.

The documentation has been extensively updated to explain:
- The new import syntax and behavior
- Why tokenColors need special handling
- How to structure imports for maintainable themes

The implementation now correctly handles tokenColors as a special case during import merging, ensuring proper rule precedence in the final theme.