### PR TITLE
Improve lint command with file locations and bump version to 0.20.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/output
 !.vscode/launch.json
 test.bash
 temp/
+tmp/

--- a/examples/advanced/src/corporate.yaml
+++ b/examples/advanced/src/corporate.yaml
@@ -7,8 +7,7 @@ config:
   import:
     - ../import/variables.yaml
     - ../import/colors.yaml
-    - ../import/token-colors-$(type).yaml
-    - ../import/token-colors-$(type)-universal.yaml
+    - ../../../karyprocolors-dark.tmLanguage.yaml
 
   custom:
     semanticHighlighting: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/sassy",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "displayName": "Sassy",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/cli.js
+++ b/src/cli.js
@@ -80,6 +80,7 @@ void (async function main() {
     c.alias.set("muted-bracket", "{F244}")
     // Lint command
     c.alias.set("context", "{F159}")
+    c.alias.set("loc", "{F148}")
     // Resolve command
     c.alias.set("head", "{F220}")
     c.alias.set("leaf", "{F151}")


### PR DESCRIPTION
# Improved Linting Output and Added Support for External Token Colors

This PR enhances the linting functionality by providing more detailed and colorful output for various issues:

- Added file location information to lint messages, making it easier to identify where problems occur
- Improved unused variable reporting to show where the variable is defined
- Enhanced duplicate scope and precedence issue messages with better formatting

Additionally:
- Updated the corporate theme example to use an external token colors file
- Added `tmp/` to gitignore
- Bumped version to 0.20.0

The changes make debugging theme issues more straightforward by providing clearer context about where problems originate.