### PR TITLE
Fix watch mode by building themes before setting up watchers

### DIFF
--- a/examples/advanced/src/corporate.yaml
+++ b/examples/advanced/src/corporate.yaml
@@ -7,7 +7,7 @@ config:
   import:
     - ../import/variables.yaml
     - ../import/colors.yaml
-    - ../../../karyprocolors-dark.tmLanguage.yaml
+    - ../import/token-colors-dark.yaml
 
   custom:
     semanticHighlighting: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/sassy",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "displayName": "Sassy",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",


### PR DESCRIPTION
# Fix watch mode by building themes before setting up watchers

This PR addresses an issue with watch mode by reordering the build process. Now, themes are built at least once before setting up file watchers, ensuring that dependencies are properly loaded. This is crucial for the watching functionality to work correctly.

Additionally, the PR updates the import path in the corporate theme example to use a more specific token colors file from the import directory.

The version has been bumped to 0.20.1 to reflect these changes.