### PR TITLE
Fix watcher event handler binding and bump version to 0.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/sassy",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "displayName": "Sassy",
   "description": "Make gorgeous themes that speak as boldly as you do.",
   "publisher": "gesslar",

--- a/src/Session.js
+++ b/src/Session.js
@@ -329,7 +329,7 @@ export default class Session {
       }
     })
 
-    this.#watcher.on("change", await this.#handleFileChange.bind(this))
+    this.#watcher.on("change", this.#handleFileChange.bind(this))
   }
 
   /**


### PR DESCRIPTION
# Fix watcher event handler binding in Session.js

This PR fixes an issue in the `Session.js` file where the file watcher's change event handler was incorrectly using `await` with `bind()`. The `await` keyword has been removed from the event handler binding, as `bind()` returns a function reference and doesn't return a promise that needs to be awaited.

Version bumped from 0.20.1 to 0.20.2 to reflect this bugfix.