### PR TITLE
04 10 clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ know where you can know the new know.
 
 ## License
 
-`@gesslar/sassy` is released into the public domain under the [0BSD](LICENSE.txt).
+`@gesslar/sassy` is released under the [0BSD](LICENSE.txt).
 
 This package includes or depends on third-party components under their own
 licenses:

--- a/docs/src/content/docs/features.md
+++ b/docs/src/content/docs/features.md
@@ -167,4 +167,3 @@ sidebar:
 - **TypeScript Definitions** — Auto-generated `.d.ts` files from JSDoc for editor support
 - **Docusaurus Documentation Site** — Full docs at sassy.gesslar.io
 - **Example Themes** — Simple and advanced examples included in the repository
-- **Unlicense** — Use however you want — no restrictions

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@gesslar/sassy",
       "version": "5.20.1",
-      "license": "Unlicense",
+      "license": "0BSD",
       "dependencies": {
         "@gesslar/colours": "^1.0.0",
         "@gesslar/toolkit": "^5.0.1",
@@ -22,7 +22,7 @@
         "sassy": "src/cli.js"
       },
       "devDependencies": {
-        "@gesslar/uglier": "^2.4.0",
+        "@gesslar/uglier": "^2.4.1",
         "eslint": "^10.2.0",
         "typescript": "^6.0.2"
       },
@@ -38,17 +38,17 @@
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
-      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.54.0",
-        "comment-parser": "1.4.5",
+        "@typescript-eslint/types": "^8.58.0",
+        "comment-parser": "1.4.6",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.1.1"
+        "jsdoc-type-pratt-parser": "~7.2.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -201,25 +201,25 @@
       }
     },
     "node_modules/@gesslar/uglier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/uglier/-/uglier-2.4.0.tgz",
-      "integrity": "sha512-xKTp04/UPeCflRIy4AOpuKSFHdnJGZEy82Xa5yUd/qGjPL6nDXfCeSv+F3e64+eon6XxpNrdUJ3NQpCYv6U46A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/uglier/-/uglier-2.4.1.tgz",
+      "integrity": "sha512-v4yxIoatmfQDpew1uR2Ro6XK5rFEwPu5WbPrbXQ6EOynJHY5wJbi4tfuZxYOdKG81zZIpqFFcn8jh/7h7lZB0w==",
       "dev": true,
-      "license": "Unlicense",
+      "license": "0BSD",
       "dependencies": {
-        "@gesslar/colours": ">=0.8.0",
-        "@gesslar/toolkit": ">=4.4.0",
+        "@gesslar/colours": ">=1.0.0",
+        "@gesslar/toolkit": ">=5.0.1",
         "@skarab/detect-package-manager": ">=1.0.0",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "eslint-plugin-astro": "^1.6.0",
-        "eslint-plugin-jsdoc": ">=62.8.1",
+        "eslint-plugin-astro": "^1.7.0",
+        "eslint-plugin-jsdoc": ">=62.9.0",
         "globals": ">=17.4.0"
       },
       "bin": {
         "uglier": "src/install.js"
       },
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -411,14 +411,14 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -443,13 +443,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.58.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/eslint-plugin-astro": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.6.0.tgz",
-      "integrity": "sha512-yGIbLHuj5MOUXa0s4sZ6cVhv6ehb+WLF80tsrGaxMk6VTUExruMzubQDzhOYt8fbR1c9vILCCRSCsKI7M1whig==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.7.0.tgz",
+      "integrity": "sha512-89xpAn528UKCdmyysbg0AHHqi6sqcK89wXnJIpu4F0mFBN03zATEBNK7pRtMfl6gwtMOm5ECXs+Wz5qDHhwTFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -848,19 +848,19 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.1.tgz",
-      "integrity": "sha512-e9358PdHgvcMF98foNd3L7hVCw70Lt+YcSL7JzlJebB8eT5oRJtW6bHMQKoAwJtw6q0q0w/fRIr2kwnHdFDI6A==",
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/jsdoccomment": "~0.86.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.5",
+        "comment-parser": "1.4.6",
         "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.1.0",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.0",
@@ -1336,9 +1336,9 @@
       "license": "ISC"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
-      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1615,9 +1615,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/sassy",
-  "version": "5.20.1",
+  "version": "5.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/sassy",
-      "version": "5.20.1",
+      "version": "5.20.2",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/colours": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "yaml-eslint-parser": "^2.0.0"
   },
   "devDependencies": {
-    "@gesslar/uglier": "^2.4.0",
+    "@gesslar/uglier": "^2.4.1",
     "eslint": "^10.2.0",
     "typescript": "^6.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "5.20.1",
+  "version": "5.20.2",
   "license": "0BSD",
   "homepage": "https://sassy.gesslar.io/",
   "repository": {


### PR DESCRIPTION
- **clarification**
- **5.20.2**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the project licence from "Unlicense" to "0BSD" across all relevant files and bumps the version to 5.20.2, accompanied by a patch update to `@gesslar/uglier` (2.4.0 → 2.4.1) and several transitive dev-dependency refreshes (postcss, typescript-eslint, comment-parser, jsdoc-type-pratt-parser, etc.).

Key changes:
- `README.md`: Removes the inaccurate "into the public domain" phrasing, keeping "released under the [0BSD]" — technically correct since 0BSD is not a public-domain dedication.
- `docs/src/content/docs/features.md`: Drops the "Unlicense" feature bullet that no longer applies.
- `package.json` / `package-lock.json`: Corrects the `license` field from `"Unlicense"` to `"0BSD"`, bumps `@gesslar/uglier` and cascading transitive deps.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to licence metadata corrections, documentation updates, and routine dev-dependency bumps with no functional code touched.

All changes are purely metadata (licence field, version number, wording in docs) and dev-dependency version upgrades. No source logic was modified, no new APIs introduced, and no security-sensitive paths were altered. The licence correction from 'Unlicense' to '0BSD' is consistent across package.json, package-lock.json, README, and docs.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["5.20.2"](https://github.com/gesslar/sassy/commit/78b9528c2a1c0b199502824453f714a0bdc7f6e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28072345)</sub>

<!-- /greptile_comment -->