### PR TITLE
Bump version to 5.20.3 and update dependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "update": "npx npm-check-updates -u && npm install"
+    "update": "npx -y npm-check-updates -u && npm install"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/sassy",
-  "version": "5.20.2",
+  "version": "5.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/sassy",
-      "version": "5.20.2",
+      "version": "5.20.3",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/colours": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,20 @@
       "license": "0BSD",
       "dependencies": {
         "@gesslar/colours": "^1.0.0",
-        "@gesslar/toolkit": "^5.0.1",
+        "@gesslar/toolkit": "^5.9.1",
         "color-support": "^1.1.3",
         "commander": "^15.0.0",
         "culori": "^4.0.2",
-        "globby": "^16.2.0",
-        "yaml": "^2.8.3",
-        "yaml-eslint-parser": "^2.0.0"
+        "globby": "^16.2.2",
+        "yaml": "^2.9.0",
+        "yaml-eslint-parser": "^2.1.0"
       },
       "bin": {
         "sassy": "src/cli.js"
       },
       "devDependencies": {
         "@gesslar/uglier": "^2.4.1",
-        "eslint": "^10.2.0",
+        "eslint": "^10.8.0",
         "typescript": "^7.0.2"
       },
       "engines": {
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@gesslar/toolkit": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.8.0.tgz",
-      "integrity": "sha512-x0eFiPjkPbH0SvWSo1bV0HSI3MashS0EOrQmsUeqja7MK7Rlt87oTaKGdPOUnwg5cwDmlYZDayZ7JokxOOjxzw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.9.1.tgz",
+      "integrity": "sha512-SjfcMGZxu1IDVJQznO87p8whs3T3O9/b1DxEwz1uq+HHZB+JNsKAoeNzW/TkJ7GWn9ioM0HUEya3ISB+FcB8Nw==",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1072,7 +1072,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -1096,7 +1096,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "5.20.2",
+  "version": "5.20.3",
   "license": "0BSD",
   "homepage": "https://sassy.gesslar.io/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:coverage": "node --experimental-test-coverage --test tests/**/*.test.js",
     "submit": "npm publish --access public --//registry.npmjs.org/:_authToken=\"${NPM_ACCESS_TOKEN}\"",
     "examples": "node ./examples/validator.js",
-    "update": "npx npm-check-updates -u && npm install",
+    "update": "npx -y npm-check-updates -u && npm install",
     "docs": "gh workflow run ReleaseStarlight.yaml",
     "pr": "gt submit -p --ai",
     "patch": "npm version patch",
@@ -58,17 +58,17 @@
   },
   "dependencies": {
     "@gesslar/colours": "^1.0.0",
-    "@gesslar/toolkit": "^5.0.1",
+    "@gesslar/toolkit": "^5.9.1",
     "color-support": "^1.1.3",
     "commander": "^15.0.0",
     "culori": "^4.0.2",
-    "globby": "^16.2.0",
-    "yaml": "^2.8.3",
-    "yaml-eslint-parser": "^2.0.0"
+    "globby": "^16.2.2",
+    "yaml": "^2.9.0",
+    "yaml-eslint-parser": "^2.1.0"
   },
   "devDependencies": {
     "@gesslar/uglier": "^2.4.1",
-    "eslint": "^10.2.0",
+    "eslint": "^10.8.0",
     "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
Bumps the package version to 5.20.3 and updates several dependencies to their latest versions:

- `@gesslar/toolkit` from `^5.0.1` to `^5.9.1`
- `globby` from `^16.2.0` to `^16.2.2`
- `yaml` from `^2.8.3` to `^2.9.0`
- `yaml-eslint-parser` from `^2.0.0` to `^2.1.0`
- `eslint` from `^10.2.0` to `^10.8.0`

Also adds the `-y` flag to the `npx npm-check-updates` call in the `update` script to suppress the install prompt.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the package release metadata and dependency baselines.
- Bumps `@gesslar/sassy` from 5.20.2 to 5.20.3.
- Updates production and development dependencies and refreshes their lockfile resolutions.
- Adds automatic confirmation to the root and documentation dependency-update scripts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (5): Last reviewed commit: ["5.20.3"](https://github.com/gesslar/sassy/commit/174d3f4e083fd3e7e41f2138cd4fa3df45765fe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47310902)</sub>

<!-- /greptile_comment -->