### PR TITLE
allow CI on all PRs

### DIFF
--- a/.github/workflows/Quality.yaml
+++ b/.github/workflows/Quality.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflow now runs quality checks for pull requests targeting any branch instead of only `main`.
- Removes the `pull_request.branches` filter from the Quality workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["empty"](https://github.com/gesslar/sassy/commit/db21c27b7f8ec933a87200e95937bb2c7cfd2984) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47311545)</sub>

<!-- /greptile_comment -->